### PR TITLE
Added notice to advise users to use `create-keystone-app` going forward.

### DIFF
--- a/.changeset/olive-buttons-greet.md
+++ b/.changeset/olive-buttons-greet.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-next-app': patch
+---
+
+Added notice to advise users to use `create-keystone-app` instead of `create-keystone-next-app`.

--- a/create-keystone-next-app/src/index.ts
+++ b/create-keystone-next-app/src/index.ts
@@ -34,6 +34,20 @@ type Args = {
   databaseUrl: string;
 };
 
+const versionInfo = () => {
+  process.stdout.write('\n');
+  console.log(`🛑  ${c.bold(`NO LONGER MAINTAINED`)}
+
+⚠️   This package ${c.bold(
+    `create-keystone-next-app`
+  )} is outdated and no longer maintained.
+
+👉  Please use ${c.bold(
+    `create-keystone-app`
+  )} instead to generate a new ${c.bold(`Keystone Next`)} project.
+  `);
+};
+
 async function normalizeArgs(): Promise<Args> {
   let directory = cli.input[0];
   if (!directory) {
@@ -97,6 +111,7 @@ const installDeps = async (cwd: string): Promise<'yarn' | 'npm'> => {
 };
 
 (async () => {
+  versionInfo();
   await checkVersion();
   const normalizedArgs = await normalizeArgs();
   await fs.mkdir(normalizedArgs.directory);


### PR DESCRIPTION
Added notice to advise users to use `create-keystone-app` instead of `create-keystone-next-app`.